### PR TITLE
Fixs web  typescript paths

### DIFF
--- a/app/web/tsconfig.json
+++ b/app/web/tsconfig.json
@@ -9,7 +9,16 @@
       "dom",
       "es2017",
       "esnext"
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@asset/*": ["asset/*"],
+      "@component/*": ["component/*"],
+      "@framework/*": ["framework/*"],
+      "@store/*": ["page/store/*"],
+      "@router/*": ["page/admin/home/router/*"],
+      "@view/*": ["page/admin/home/view/*"]
+    }
   },
   "include": [
     "./**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,16 +7,7 @@
     /* Experimental Options */
     "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-    "strictNullChecks": false,
-    "baseUrl": "app/web",
-    "paths": {
-      "@asset/*": ["asset/*"],
-      "@component/*": ["component/*"],
-      "@framework/*": ["framework/*"],
-      "@store/*": ["page/store/*"],
-      "@router/*": ["page/router/*"],
-      "@view/*": ["page/view/*"]
-    }
+    "strictNullChecks": false
   },
   "include": [
     "index.ts",


### PR DESCRIPTION
Hi
使用该骨架开发的时候发现 web 文件夹下的相对路径映射 paths 无效，ts 检查会有下图警告。

![reappear](https://user-images.githubusercontent.com/45227720/93100845-33c4e080-f6dc-11ea-8eb6-08eb0dc6809c.png)

这个 commit 修改了 web 文件夹下的 tsconfig.json 修复该问题。